### PR TITLE
Specify Drupal 9 support in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "drupal/core": "^8.9",
+        "drupal/core": "^8.9 || ^9",
         "php": ">=7.2"
     },
     "require-dev": {


### PR DESCRIPTION
I can't require this module in Composer for a Drupal 9 project, because the composer.json specifies only ^8.9 right now.