### PR TITLE
EWPP-2703: Item weight should reflect the current number of items sortable.

### DIFF
--- a/src/Element/MultiValue.php
+++ b/src/Element/MultiValue.php
@@ -213,6 +213,11 @@ class MultiValue extends FormElement {
         '#type' => 'weight',
         '#title' => t('Weight for row @number', ['@number' => $i + 1]),
         '#title_display' => 'invisible',
+        // Note: this 'delta' is the FAPI #type 'weight' element's property.
+        // Without it the available range of numbers won't correspond to
+        // the max number of items in the weight select, causing ordering
+        // issues over 20 items.
+        '#delta' => $max,
         '#default_value' => $i,
         '#weight' => 100,
       ];

--- a/src/Element/MultiValue.php
+++ b/src/Element/MultiValue.php
@@ -55,7 +55,7 @@ use Drupal\Core\Render\Element\FormElement;
  *     '#title' => $this->t('E-mail'),
  *   ],
  * ];
- * @endCode
+ * @endcode
  *
  * Default values can be set to the multi-value form element. Never set them in
  * child elements as they will be overridden.
@@ -67,9 +67,8 @@ use Drupal\Core\Render\Element\FormElement;
  *     0 => ['name' => 'Bob', 'mail' => 'bob@example.com'],
  *     1 => ['name' => 'Ted', 'mail' => 'ted@example.com'],
  *   ],
- *   ...
  * ];
- * @endCode
+ * @endcode
  *
  * If only one child element is present, said child element name can be omitted
  * from the default value array:
@@ -78,7 +77,6 @@ use Drupal\Core\Render\Element\FormElement;
  *   '#type' => 'multivalue',
  *   '#title' => $this->t('Job titles'),
  *   'title' => [
- *     ...
  *   ],
  *   '#default_value' => [
  *     'Foo',
@@ -118,7 +116,7 @@ use Drupal\Core\Render\Element\FormElement;
  *     '#title' => $this->t('E-mail'),
  *   ],
  * ];
- * @endCode
+ * @endcode
  *
  * If you want to have some children required in all the deltas, use #states
  * to mark the wanted elements as required if one of the other children is

--- a/tests/src/Functional/MultiValueElementTest.php
+++ b/tests/src/Functional/MultiValueElementTest.php
@@ -180,9 +180,9 @@ class MultiValueElementTest extends BrowserTestBase {
     $assert_session->fieldExists('bar[0][number]')->setValue(1);
     $assert_session->fieldExists('bar[0][_weight]')->setValue(0);
     $assert_session->fieldExists('bar[1][number]')->setValue(2);
-    $assert_session->fieldExists('bar[1][_weight]')->setValue(-10);
+    $assert_session->fieldExists('bar[1][_weight]')->setValue(-2);
     $assert_session->fieldExists('bar[2][number]')->setValue(3);
-    $assert_session->fieldExists('bar[2][_weight]')->setValue(-5);
+    $assert_session->fieldExists('bar[2][_weight]')->setValue(-1);
     $assert_session->buttonExists('Submit')->press();
     $submitted_values = $this->getSubmittedFormValues();
     $this->assertEquals([


### PR DESCRIPTION
The weight elements do not have a delta defined, so they default to 10. This generate values between -10 and 10, causing ordering issues when more than 20 items are present.